### PR TITLE
[FIX] Issue #3 - Unable to play media

### DIFF
--- a/zeitgeist.html
+++ b/zeitgeist.html
@@ -36,10 +36,10 @@
 <body>
      <div class="return">
         <a href="index.html"><h1>Go back</h1>
-            <p>for some reason this album doesn't work :( scroll to bottom for infomation</p>
+            <p>scroll to bottom for infomation</p>
         </a>
     </div>
-    <iframe style="border-radius:12px" src="https://open.spotify.com/embed/playlist/1H01AGSbyHJmVIYAWf1qcT?utm_source=generator"width="100%" height="1000px"  frameBorder="0" allowfullscreen="" allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture" loading="lazy"></iframe>
+    <iframe width="100%" height="300" scrolling="no" frameborder="no" allow="autoplay" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/playlists/1490563744&color=%23ff5500&auto_play=false&hide_related=false&show_comments=true&show_user=true&show_reposts=false&show_teaser=true&visual=true"></iframe><div style="font-size: 10px; color: #cccccc;line-break: anywhere;word-break: normal;overflow: hidden;white-space: nowrap;text-overflow: ellipsis; font-family: Interstate,Lucida Grande,Lucida Sans Unicode,Lucida Sans,Garuda,Verdana,Tahoma,sans-serif;font-weight: 100;"><a href="https://soundcloud.com/eddie-devito" title="Eddie devito" target="_blank" style="color: #cccccc; text-decoration: none;">Eddie devito</a> · <a href="https://soundcloud.com/eddie-devito/sets/the-smashing-pumpkins" title="The Smashing Pumpkins &quot;Zeitgeist&quot; (2007)" target="_blank" style="color: #cccccc; text-decoration: none;">The Smashing Pumpkins &quot;Zeitgeist&quot; (2007)</a></div>
         <div class="container">
         <h1>Zeitgeist</h1>
         <p>Zeitgeist is the seventh studio album by The Smashing Pumpkins, released on July 10, 2007. It marks the band's first album after


### PR DESCRIPTION
Replaces the Spotify embed for the 'zeitgeist.html' page with a SoundCloud one so that the media can actually be played.

This therefore fixes Issue #3 